### PR TITLE
Add TBA fallbacks for event sections and update May 2026 SPS date

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,18 +1,18 @@
 {
     "side_project_saturday": {
-        "meetup_url": "https://luma.com/1ji1e2d9",
-        "date": "2026-04-25",
+        "meetup_url": "https://luma.com/sglqlj47",
+        "date": "2026-05-30",
         "start_time": "10:00am",
-        "end_time": "2pm",
+        "end_time": "2:00pm",
         "location": {
-            "name": "IRL at Willow Grove Giant",
+            "name": "IRL at Willow Grove GIANT Community Center",
             "address1": "315 York Rd, Willow Grove, PA",
             "address2": "Slack #side-project-virtual"
         }
     },
     "main_meeting": {
       "meetup_url": "https://luma.com/i00ll61z",
-      "date": "2026-05-14",
+      "date": "",
       "start_time": "5:45pm",
       "end_time": "8:00pm",
         "location": {
@@ -23,7 +23,7 @@
     },
     "book_club": {
       "meetup_url": "https://www.meetup.com/PhillyCocoaHeads/events/nppmkrybcdbpb/",
-      "date": "2020-02-11",
+      "date": "",
       "start_time": "8:00pm",
       "end_time": "9:00pm",
         "location": {

--- a/layouts/partials/book-club-info.html
+++ b/layouts/partials/book-club-info.html
@@ -2,15 +2,18 @@
 
 <section class="event-info">
   <h3>Next Book Club</h3>
-  <p>Book Club is on break <br />
-  until further notice. <br />
-  See the #book-club <br />
-  slack room for more info.</p>
-   <!--<time datetime="{{$event.date }}">
-    {{ dateFormat "Monday, Jan 2, 2006" $event.date }}
-  </time>
-  <time>{{ $event.start_time }} to {{ $event.end_time }}</time>
+  {{ if $event.date }}
+    <time datetime="{{$event.date }}">
+      {{ dateFormat "Monday, Jan 2, 2006" $event.date }}
+    </time>
+    <time>{{ $event.start_time }} to {{ $event.end_time }}</time>
 
-  <address>{{ $event.location.name }}</address>
-  <p><a href="{{ $event.meetup_url }}">RSVP @ Meetup.com</a></p> -->
+    <address>{{ $event.location.name }}</address>
+    <p><a href="{{ $event.meetup_url }}">RSVP @ Meetup.com</a></p>
+  {{ else }}
+    <p>On break<br />
+    until further notice.<br />
+    See the #book-club<br />
+    Slack room for more info.</p>
+  {{ end }}
 </section>

--- a/layouts/partials/main-meeting-description.html
+++ b/layouts/partials/main-meeting-description.html
@@ -1,5 +1,13 @@
+{{ $event := hugo.Data.events.main_meeting }}
+
+{{ if $event.date }}
 <p>Our next Main Meeting is <strong>Beyond the Simulator: Perspectives on Modern App Development</strong>, hosted by Vanguard at 2300 Chestnut St in Philadelphia. We will have talks from fellow developers and designers on topics ranging from UI design to AI integration, including Metal shaders and using Claude Code with Xcode.</p>
 
 <p>The evening starts with meet-and-greeting time, followed by introductions, community news, short talks, and cleanup. Capacity is limited, so please RSVP if you plan to attend in person. A Teams link will also be available for watching the presentations live.</p>
 
 <p>If you have any questions or would like to present at the meeting, please get in touch with the leadership team, <a href="mailto:leadership@phillycocoa.org">leadership@phillycocoa.org</a>.</p>
+{{ else }}
+<p>Our main meeting is held once a month, usually on the second Thursday of the month. The meeting starts with social time and help time, followed by introductions, community news, and presentations. These talks can range from short member demos to longer featured sessions. All are welcome to join us.</p>
+
+<p>If you are interested in presenting or helping organize a future meeting, please get in touch with the leadership team, <a href="mailto:leadership@phillycocoa.org">leadership@phillycocoa.org</a>.</p>
+{{ end }}

--- a/layouts/partials/main-meeting-info.html
+++ b/layouts/partials/main-meeting-info.html
@@ -2,14 +2,17 @@
 
 <section class="event-info">
   <h3>Next Main Meeting</h3>
-   <!--<p>The next Main Meeting is TBD</p>-->
-  <time datetime="{{$event.date }}">
-    {{ dateFormat "Monday, Jan 2, 2006" $event.date }}
-  </time>
-  <time>{{ $event.start_time }} to {{ $event.end_time }}</time>
+  {{ if $event.date }}
+    <time datetime="{{$event.date }}">
+      {{ dateFormat "Monday, Jan 2, 2006" $event.date }}
+    </time>
+    <time>{{ $event.start_time }} to {{ $event.end_time }}</time>
 
-  <address>{{ $event.location.name }}<br>
-  {{ $event.location.address1 }}<br>
-  {{ $event.location.address2 }}</address>
-  <p><a href="{{ $event.meetup_url }}">RSVP @ Luma</a></p>
+    <address>{{ $event.location.name }}<br>
+    {{ $event.location.address1 }}<br>
+    {{ $event.location.address2 }}</address>
+    <p><a href="{{ $event.meetup_url }}">RSVP @ Luma</a></p>
+  {{ else }}
+    <p>TBA</p>
+  {{ end }}
 </section>

--- a/layouts/partials/side-project-saturday-description.html
+++ b/layouts/partials/side-project-saturday-description.html
@@ -1,1 +1,7 @@
+{{ $event := hugo.Data.events.side_project_saturday }}
+
+{{ if $event.date }}
 <p>Side Project Saturday is an unique opportunity to work on your iOS or Mac projects in a group setting. It's a great chance to get help with your app, share your ideas, get feedback and socialize with other local Apple developers! Beginners are always welcome! Come and go as you please.</p>
+{{ else }}
+<p>Side Project Saturday is an unique opportunity to work on your iOS or Mac projects in a group setting. It's a great chance to get help with your app, share your ideas, get feedback and socialize with other local Apple developers! Beginners are always welcome! Come and go as you please.</p>
+{{ end }}

--- a/layouts/partials/side-project-saturday-info.html
+++ b/layouts/partials/side-project-saturday-info.html
@@ -2,13 +2,17 @@
 
 <section class="event-info">
   <h3>Next Side Project Saturday</h3>
-  <time datetime="{{$event.date }}">
-    {{ dateFormat "Monday, Jan 2, 2006" $event.date }}
-  </time>
-  <time>{{ $event.start_time }} to {{ $event.end_time }}</time>
+  {{ if $event.date }}
+    <time datetime="{{$event.date }}">
+      {{ dateFormat "Monday, Jan 2, 2006" $event.date }}
+    </time>
+    <time>{{ $event.start_time }} to {{ $event.end_time }}</time>
 
-  <address>{{ $event.location.name }}<br>
-  {{ $event.location.address1 }}<br>
-  {{ $event.location.address2 }}</address>
-  <p><a href="{{ $event.meetup_url }}">RSVP @ Luma</a></p>
+    <address>{{ $event.location.name }}<br>
+    {{ $event.location.address1 }}<br>
+    {{ $event.location.address2 }}</address>
+    <p><a href="{{ $event.meetup_url }}">RSVP @ Luma</a></p>
+  {{ else }}
+    <p>TBA</p>
+  {{ end }}
 </section>


### PR DESCRIPTION
## Summary
- Added conditional TBA fallbacks for the main meeting, Side Project Saturday, and book club blocks when their dates are empty.
- Kept the body copy evergreen for the empty states and removed redundant TBA phrasing from the callout boxes.
- Updated the Side Project Saturday data to the May 30, 2026 Luma event.

## Testing
- Ran a local Hugo build successfully.
- Verified the updated event states in the running preview during manual UI checks.