### PR TITLE
Refresh About page leadership and hosting links

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -26,56 +26,28 @@ Our main event calendar is also on [Meetup.com](https://www.meetup.com/PhillyCoc
 <ol class="leadership">
 
 <li>
-  <img src="https://www.gravatar.com/avatar/9b54e5324785eb939bcc8f15c724baf9?s=150" alt="Curtis Herbert Profile Photo">
-  <ol class="info">
-  <li class="name">Curtis Herbert</li>
-  <li class="twitter"><a href="http://twitter.com/parrots">@parrots</a></li>
-  <li class="responsibilities">(Board Member / Main Meetings /<br> Videos)</li>
-  </ol>
-</li>
-
-
-
-<li>
-  <img src="https://www.gravatar.com/avatar/b05e7cfb32dbd2c3ed159a1ac1e15165?s=150" alt="Stephen Tolton Profile Photo">
-  <ol class="info">
-  <li class="name">Stephen Tolton</li>
-  <li class="twitter"><a href="http://twitter.com/stolton">@stolton</a></li>
-  <li class="responsibilities">(Board Member / Side Project <br>Saturdays / Podcast)</li>
-  </ol>
-</li>
-
-<li>
-  <img src="https://www.gravatar.com/avatar/7aef4a1b4f67f1db1ff5ed28a7ac81ed?s=150" alt="Kotaro Fujita Profile Photo">
+  <img src="https://www.gravatar.com/avatar/7aef4a1b4f67f1db1ff5ed28a7ac81ed?s=150" width="150" height="150" alt="Kotaro Fujita Profile Photo">
   <ol class="info">
   <li class="name">Kotaro Fujita</li>
   <li class="twitter"><a href="http://twitter.com/wild37">@wild37</a></li>
-  <li class="responsibilities">(Board Member / Main Meeting Greeter /<br> Twitter / Podcast)</li>
+  <li class="responsibilities">(Main Meetings /<br> Twitter / Podcast)</li>
   </ol>
 </li>
 
 <li>
-  <img src="{{ .Site.BaseURL }}images/matt_profile_pic_sized.jpg" alt="Matthew Toto">
+  <img src="https://www.gravatar.com/avatar/8d85b5ebc7056d992ac013713173473c?s=150" width="150" height="150" alt="Stephen Tolton Profile Photo">
   <ol class="info">
-  <li class="name">Matthew Toto</li>
-  <li class="responsibilities">(Book Club)</li>
+  <li class="name">Stephen Tolton</li>
+  <li class="twitter"><a href="http://twitter.com/stolton">@stolton</a></li>
+  <li class="responsibilities">(Side Project <br>Saturdays / Podcast)</li>
   </ol>
 </li>
 
 <li>
-  <img src="https://www.gravatar.com/avatar/42267223014b3d0ec4f033ffe7cbda92?s=150" alt="Matt Smollinger Profile Photo">
+  <img src="https://www.gravatar.com/avatar/42267223014b3d0ec4f033ffe7cbda92?s=150" width="150" height="150" alt="Matt Smollinger Profile Photo">
   <ol class="info">
   <li class="name">Matt Smollinger</li>
   <li class="twitter"><a href="http://twitter.com/mattsmollinger">@mattsmollinger</a></li>
-  <li class="responsibilities">(Website / Future Projects)</li>
-  </ol>
-</li>
-
-<li>
-  <img src="https://www.gravatar.com/avatar/41d38d758bfcbc0d546189dbc1d2fee9?s=150" alt="Gillian Reynolds-Titko Profile Photo">
-  <ol class="info">
-  <li class="name">Gillian Reynolds-Titko</li>
-  <li class="twitter"><a href="https://www.linkedin.com/in/gillianreynoldstitko/">LinkedIn</a></li>
   <li class="responsibilities">(Website / Future Projects)</li>
   </ol>
 </li>
@@ -89,6 +61,9 @@ We'd like to also thank the following people for their past efforts helping run 
 * Tom Piarulli, [@tompark_IO](https://twitter.com/tompark_IO)
 * Mike Zornek, [Website](http://mikezornek.com)
 * Michael Mayer, [@jm2software](http://twitter.com/jm2software)
+* Curtis Herbert, [@parrots](http://twitter.com/parrots)
+* Matthew Toto
+* Gillian Reynolds-Titko, [LinkedIn](https://www.linkedin.com/in/gillianreynoldstitko/)
 
 ## Blog Tools
 

--- a/content/about.md
+++ b/content/about.md
@@ -61,7 +61,7 @@ We'd like to also thank the following people for their past efforts helping run 
 * Tom Piarulli, [@tompark_IO](https://twitter.com/tompark_IO)
 * Mike Zornek, [Website](http://mikezornek.com)
 * Michael Mayer, [@jm2software](http://twitter.com/jm2software)
-* Curtis Herbert, [@parrots](http://twitter.com/parrots)
+* Curtis Herbert, [Website](https://curtisherbert.com)
 * Matthew Toto
 * Gillian Reynolds-Titko, [LinkedIn](https://www.linkedin.com/in/gillianreynoldstitko/)
 
@@ -71,6 +71,5 @@ Our thanks to the following open source projects for giving us the tools to help
 
 * [Hugo](https://gohugo.io/), a static site generator written in [Go](https://golang.org/).
 * [GitHub](https://github.com/) for source control hosting.
-* [CircleCI](https://circleci.com/) for deployment.
-* [Amazon S3](https://aws.amazon.com/s3/) for web hosting.
+* [Cloudflare Pages](https://pages.cloudflare.com/) for deployment and web hosting.
 * [Hover](https://www.hover.com/) for domain name management.

--- a/themes/phillycocoaheadtheme/static/css/main.css
+++ b/themes/phillycocoaheadtheme/static/css/main.css
@@ -133,27 +133,42 @@ header ol li {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
+  padding-left: 0;
 }
 
-.leadership li {
+.leadership > li {
   margin-bottom: 1em;
   display: flex;
   width: 450px;
 }
 
-.leadership img {
+.leadership > li > img {
+  display: block;
+  width: 150px !important;
+  height: 150px !important;
+  min-width: 150px;
+  max-width: 150px;
+  min-height: 150px;
+  max-height: 150px;
+  flex: 0 0 150px;
   margin-right: 1em;
   border-radius: 50%;
+  object-fit: cover;
+  object-position: center;
 }
 
 .leadership .info {
-  display: inline;
+  display: block;
+  list-style: none;
   margin: 0;
   padding: 0;
 }
 
 .leadership .info li {
+  display: block;
+  list-style: none;
   margin-bottom: 0;
+  width: auto;
 }
 
 .leadership .info li.name {


### PR DESCRIPTION
## Summary
- Reorder the leadership list and move Curtis, Matthew Toto, and Gillian into the past-efforts section.
- Update Curtis’s past-efforts link to his website and replace the legacy deployment tools with Cloudflare Pages.
- Add fixed size constraints to leadership portraits so they render consistently without distortion.

## Testing
- `hugo` build completed successfully.
- Verified the About page markup and rendered leadership image sizing locally in the browser.